### PR TITLE
Motors in motor controller are now named according to their position on the sub. 

### DIFF
--- a/ros/src/monitor/devices.json
+++ b/ros/src/monitor/devices.json
@@ -3,7 +3,7 @@
 	"ignore" : false,
         "baud" : 9600,
         "ack_message" : "RID\n",
-        "ack_response" : "Motor_controller\r\n",
+        "ack_response" : "Motor Controller\r\n",
         "timeout": 1000,
         "convert_to_bytes" : false
     },

--- a/ros/src/peripherals/CMakeLists.txt
+++ b/ros/src/peripherals/CMakeLists.txt
@@ -25,6 +25,7 @@ add_message_files(
   powerboard.msg
   imu.msg
   orientation.msg
+  motor_info.msg
 )
 
 ## Generate added messages and services with any dependencies listed here

--- a/ros/src/peripherals/launchfiles/motors.launch
+++ b/ros/src/peripherals/launchfiles/motors.launch
@@ -1,5 +1,5 @@
 <launch>
-    <arg name="device_id" default="Motor Controller"/>
+    <arg name="device_id" default="motor_controller"/>
     <node name="motor_controller" pkg="peripherals" type="motor_controller" respawn="true" respawn_delay="1" >
         <param name="device_id" value="$(arg device_id)"/>
     </node>

--- a/ros/src/peripherals/msg/motor_info.msg
+++ b/ros/src/peripherals/msg/motor_info.msg
@@ -1,0 +1,3 @@
+string name
+int16 pwm
+int16 rpm

--- a/ros/src/peripherals/src/motor_controller.cpp
+++ b/ros/src/peripherals/src/motor_controller.cpp
@@ -1,13 +1,17 @@
 #include <ros/ros.h>
 #include <string>
 #include <memory>
+#include <map>
 #include <serial/serial.h>
 #include "peripherals/motor.h"
 #include "peripherals/motors.h"
 #include "monitor/GetSerialDevice.h"
 
 #define NUM_MOTORS (8)
-#define NUM_CHAR_PER_MOTOR (2)
+#define NUM_CHAR_PER_RPM (2)
+#define NUM_CHAR_PER_PWM (2)
+#define NUM_CHAR_PER_DIR (1)
+#define MAX_MOTOR_VALUE (99)
 
 using MotorReq = peripherals::motor::Request;
 using MotorRes = peripherals::motor::Response;
@@ -19,20 +23,31 @@ class motor_controller {
 public:
     motor_controller(const std::string & port, int baud_rate = 9600, int timeout = 1000);
     ~motor_controller();
-    bool setMotorForward(MotorReq &, MotorRes &);
-    bool setMotorReverse(MotorReq &, MotorRes &);
+    bool setMotorPWM(MotorReq &req, MotorRes &res);
     bool setAllMotors(MotorsReq &req, MotorsRes &res);
     bool stopMotor(MotorReq &req, MotorRes &res);
     bool stopAllMotors(MotorReq &, MotorRes &);
     bool getRPM(MotorsReq &, MotorsRes &);
+    bool getMotorNames(MotorsReq &, MotorsRes &);
 private:
     std::unique_ptr<serial::Serial> connection = nullptr;
+    std::map<std::string, uint8_t> motor_names_to_number;
     std::string write(const std::string & out, bool ignore_response = true, std::string eol = "\n");
 };
 
 motor_controller::motor_controller(const std::string & port, int baud_rate, int timeout) {
     ROS_INFO("Connecting to motor_controller on port: %s", port.c_str());
     connection = std::unique_ptr<serial::Serial>(new serial::Serial(port, (u_int32_t) baud_rate, serial::Timeout::simpleTimeout(timeout)));
+
+    // Setup the motor name lookup dictionary
+    motor_names_to_number["Z_Front_Right"] = 4;
+    motor_names_to_number["Z_Front_Left"] = 3;
+    motor_names_to_number["Z_Back_Right"] = 7;
+    motor_names_to_number["Z_Back_Left"] = 6;
+    motor_names_to_number["X_Right"] = 1;
+    motor_names_to_number["X_Left"] = 8;
+    motor_names_to_number["Y_Front"] = 2;
+    motor_names_to_number["Y_Back"] = 5;
 }
 
 motor_controller::~motor_controller() {
@@ -42,48 +57,62 @@ motor_controller::~motor_controller() {
 
 std::string motor_controller::write(const std::string & out, bool ignore_response, std::string eol)
 {
+    connection->flush();
     connection->write(out + eol);
-    //ROS_INFO("%s", out.c_str());
+    ROS_ERROR("%s", out.c_str());
     if (ignore_response) {
         return "";
     }
     return connection->readline(65536ul, eol);
 }
 
-bool motor_controller::setMotorForward(MotorReq &req, MotorRes &res)
+bool motor_controller::setMotorPWM(MotorReq &req, MotorRes &res)
 {
-    std::string out = "M" + std::to_string(req.motor_number) + "F";
-    out += std::to_string(req.motor_argument / 10) + std::to_string(req.motor_argument % 10);
+    int16_t pwm = req.motor_in.pwm;
+    std::string out = "M" + std::to_string(motor_names_to_number[req.motor_in.name]);
+    std::string dir = "F";
+    if(pwm < 0) {
+        dir = "R";
+        pwm *= -1;
+    }
+    if(pwm > MAX_MOTOR_VALUE) {
+        pwm = MAX_MOTOR_VALUE;
+    }
+    out += dir + std::to_string(pwm);
     this->write(out);
+    res.motor_out.name = req.motor_in.name;
+    res.motor_out.pwm = pwm * ((dir == "F") ? 1 : -1);
     return true;
 }
 
-bool motor_controller::setMotorReverse(MotorReq &req, MotorRes &res)
-{
-    std::string out = "M" + std::to_string(req.motor_number) + "R";
-    out += std::to_string(req.motor_argument / 10) + std::to_string(req.motor_argument % 10);
-    this->write(out);
-    return true;
-}
-
-bool motor_controller::setAllMotors(MotorsReq &req, MotorsRes &res)
+bool motor_controller::setAllMotorsPWM(MotorsReq &req, MotorsRes &res)
 {
     std::string out = "MSA";
-    for (auto motor_power : req.arguments) {
-        std::string dir = "F";
-        if (motor_power < 0) {
-            dir = "R";
-            motor_power *= -1;
+    char* motor_pwms = new char[req.motors_in.size() * (NUM_CHAR_PER_PWM + NUM_CHAR_PER_DIR) + 1];
+    motor_pwms[req.motors_in.size() * (NUM_CHAR_PER_PWM + NUM_CHAR_PER_DIR)] = '\0';
+    for (auto motor : req.motors_in) {
+        char dir = 'F';
+        if (motor.pwm < 0) {
+            dir = 'R';
+            motor.pwm *= -1;
         }
-        out += dir + std::to_string(motor_power / 10) + std::to_string(motor_power % 10);
+        if (motor.pwm > MAX_MOTOR_VALUE) {
+            motor.pwm = MAX_MOTOR_VALUE;
+        }
+        uint8_t index = motor_names_to_number[motor.name];
+        motor_pwms[(index - 1) * (NUM_CHAR_PER_PWM + NUM_CHAR_PER_DIR)] = dir;
+        std::strncpy(&(motor_pwms[1 + (index -1) * (NUM_CHAR_PER_PWM + NUM_CHAR_PER_DIR)]),
+            std::to_string(motor.pwm).c_str(), NUM_CHAR_PER_PWM);
     }
+    out += std::string(motor_pwms);
     this->write(out);
+    delete[] motor_pwms;
     return true;
 }
 
 bool motor_controller::stopMotor(MotorReq &req, MotorRes &res)
 {
-    std::string out = "SM" + std::to_string(req.motor_number);
+    std::string out = "SM" + std::to_string(motor_names_to_number[req.motor_in.name]);
     this->write(out);
     return true;
 }
@@ -98,16 +127,34 @@ bool motor_controller::getRPM(MotorsReq &req, MotorsRes &res)
 {
     std::string rpm_string = this->write("RVA", false);
     ROS_INFO("Got: \"%s\"", rpm_string.c_str());
-    if (rpm_string.size() != (NUM_CHAR_PER_MOTOR * NUM_MOTORS) + 2) { //assuming eol is \r\n
+    if (rpm_string.size() != (NUM_CHAR_PER_PWM * NUM_MOTORS) + 2) { //assuming eol is \r\n
         return false;
     }
 
-    for (int i = 0; i < NUM_MOTORS; i++) {
-        std::string ascii_str = rpm_string.substr(i*2, 2);
-        res.results[i] = std::stoi(ascii_str);
-    } 
+    std::map<std::string, uint8_t>::iterator it;
+    for(it = motor_names_to_number.begin(); it != motor_names_to_number.end(); it++) {
+        std::string rpm_i = rpm_string.substr((it->second - 1)*2, 2);
+        peripherals::motor_info motor_i;
+
+        // Get RPM for this motor
+        motor_i.name = it->first;
+        motor_i.rpm = (int16_t)((rpm_i[1] << 8) | (rpm_i[0]));
+
+        // Add RPM to response
+        res.motors_out.push_back(motor_i);
+    }
 
     return true;
+}
+
+bool motor_controller::getMotorNames(MotorsReq &req, MotorsRes &res)
+{
+    std::map<std::string, uint8_t>::iterator it;
+    for(it = motor_names_to_number.begin(); it != motor_names_to_number.end(); it++) {
+        peripherals::motor_info motor_i;
+        motor_i.name = it->first;
+        res.motors_out.push_back(motor_i);
+    }
 }
 
 int main(int argc, char ** argv)
@@ -124,17 +171,17 @@ int main(int argc, char ** argv)
         return 1;
     }
 
-    ROS_INFO("Using Motor Controller on fd %s\n", srv.response.device_fd.c_str());
+    ROS_ERROR("Using Motor Controller on fd %s\n", srv.response.device_fd.c_str());
 
     motor_controller m(srv.response.device_fd);
 
     /* Setup all the Different services/commands which we  can call. Each service does its own error handling */
-    rosserv mf  = nh.advertiseService("setMotorForward", &motor_controller::setMotorForward, &m);
-    rosserv mr  = nh.advertiseService("setMotorReverse", &motor_controller::setMotorReverse, &m);
+    rosserv mr  = nh.advertiseService("setMotorPWM", &motor_controller::setMotorPWM, &m);
     rosserv stp = nh.advertiseService("stopAllMotors", &motor_controller::stopAllMotors, &m);
-    rosserv sm  = nh.advertiseService("stopMotors", &motor_controller::stopMotor, &m);
+    rosserv sm  = nh.advertiseService("stopMotor", &motor_controller::stopMotor, &m);
     rosserv rpm = nh.advertiseService("getRPM", &motor_controller::getRPM, &m);
-    rosserv sam = nh.advertiseService("setAllMotors", &motor_controller::setAllMotors, &m);
+    rosserv nms = nh.advertiseService("getMotorNames", &motor_controller::getMotorNames, &m);
+    rosserv sam = nh.advertiseService("setAllMotorsPWM", &motor_controller::setAllMotorsPWM, &m);
 
     /* Wait for callbacks */
     ros::spin();

--- a/ros/src/peripherals/src/motor_controller.cpp
+++ b/ros/src/peripherals/src/motor_controller.cpp
@@ -59,7 +59,7 @@ std::string motor_controller::write(const std::string & out, bool ignore_respons
 {
     connection->flush();
     connection->write(out + eol);
-    ROS_ERROR("%s", out.c_str());
+    //ROS_INFO("%s", out.c_str());
     if (ignore_response) {
         return "";
     }
@@ -167,11 +167,11 @@ int main(int argc, char ** argv)
 
     ros::ServiceClient client = nh.serviceClient<monitor::GetSerialDevice>("/serial_manager/GetDevicePort");
     if (!client.call(srv)) {
-        ROS_INFO("Couldn't get \"%s\" file descripter. Shutting down", srv.request.device_id.c_str());
+        ROS_ERROR("Couldn't get \"%s\" file descripter. Shutting down", srv.request.device_id.c_str());
         return 1;
     }
 
-    ROS_ERROR("Using Motor Controller on fd %s\n", srv.response.device_fd.c_str());
+    ROS_INFO("Using Motor Controller on fd %s\n", srv.response.device_fd.c_str());
 
     motor_controller m(srv.response.device_fd);
 

--- a/ros/src/peripherals/src/motor_controller.cpp
+++ b/ros/src/peripherals/src/motor_controller.cpp
@@ -24,7 +24,7 @@ public:
     motor_controller(const std::string & port, int baud_rate = 9600, int timeout = 1000);
     ~motor_controller();
     bool setMotorPWM(MotorReq &req, MotorRes &res);
-    bool setAllMotors(MotorsReq &req, MotorsRes &res);
+    bool setAllMotorsPWM(MotorsReq &req, MotorsRes &res);
     bool stopMotor(MotorReq &req, MotorRes &res);
     bool stopAllMotors(MotorReq &, MotorRes &);
     bool getRPM(MotorsReq &, MotorsRes &);

--- a/ros/src/peripherals/srv/motor.srv
+++ b/ros/src/peripherals/srv/motor.srv
@@ -1,3 +1,3 @@
-int8 motor_number
-int8 motor_argument
+peripherals/motor_info motor_in
 ---
+peripherals/motor_info motor_out

--- a/ros/src/peripherals/srv/motors.srv
+++ b/ros/src/peripherals/srv/motors.srv
@@ -1,3 +1,3 @@
-int8[] arguments
+peripherals/motor_info[] motors_in
 ---
-int8[] results
+peripherals/motor_info[] motors_out


### PR DESCRIPTION
Motors now have names. To set a motor speed in service call, must specify the name of the motor and the PWM it will run at. For setting all motors, send a list of motors, each with the appropriate name. A service call has been added to get all motor names from motor controller. Reasoning for this: easier to understand what is happening. When looking at messages, can see which motors were set to what, goal is to make debugging easier in the future.