### PR TITLE
Hydrophone Node Created (Issue #5)

### DIFF
--- a/ros/src/monitor/devices.json
+++ b/ros/src/monitor/devices.json
@@ -12,7 +12,7 @@
 	"ignore" : false,
         "baud" : 115200,
         "ack_message" : "RID\n",
-        "ack_response" : "Hydrophones\r\n",
+        "ack_response" : "Hydrophones v1.0\r\n",
         "timeout": 1000,
         "convert_to_bytes" : false
     },

--- a/ros/src/monitor/devices.json
+++ b/ros/src/monitor/devices.json
@@ -8,6 +8,15 @@
         "convert_to_bytes" : false
     },
     
+    "hydrophones" : {
+	"ignore" : false,
+        "baud" : 115200,
+        "ack_message" : "RID\n",
+        "ack_response" : "Hydrophones\r\n",
+        "timeout": 1000,
+        "convert_to_bytes" : false
+    },
+    
     "imu" : {
 	"ignore" : false,
         "baud" : 38400,

--- a/ros/src/peripherals/CMakeLists.txt
+++ b/ros/src/peripherals/CMakeLists.txt
@@ -17,6 +17,7 @@ add_service_files(
    FILES
    motor.srv
    motors.srv
+   hydro_data.srv
 )
 
 add_message_files(
@@ -26,6 +27,7 @@ add_message_files(
   imu.msg
   orientation.msg
   motor_info.msg
+  hydro.msg
 )
 
 ## Generate added messages and services with any dependencies listed here

--- a/ros/src/peripherals/CMakeLists.txt
+++ b/ros/src/peripherals/CMakeLists.txt
@@ -56,7 +56,10 @@ add_executable(motor_controller src/motor_controller.cpp)
 target_link_libraries(motor_controller ${catkin_LIBRARIES} ${serial_LIBRARIES})
 add_dependencies(motor_controller monitor_generate_messages_cpp peripherals_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
 
-
 add_executable(imu src/imu.cpp)
 target_link_libraries(imu ${catkin_LIBRARIES} ${serial_LIBRARIES})
 add_dependencies(imu monitor_generate_messages_cpp peripherals_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
+
+add_executable(hydrophones src/hydrophones.cpp)
+target_link_libraries(hydrophones ${catkin_LIBRARIES} ${serial_LIBRARIES})
+add_dependencies(hydrophones monitor_generate_messages_cpp peripherals_generate_messages_cpp ${catkin_EXPORTED_TARGETS})

--- a/ros/src/peripherals/launchfiles/hydrophones.launch
+++ b/ros/src/peripherals/launchfiles/hydrophones.launch
@@ -1,6 +1,10 @@
 <launch>
     <arg name="device_id" default="hydrophones"/>
+    <arg name="packet_size" default="400"/>
+    <arg name="data_size" default="32768"/>
     <node name="hydrophones" pkg="peripherals" type="hydrophones" respawn="true" respawn_delay="1" >
         <param name="device_id" value="$(arg device_id)"/>
+        <param name="packet_size" value="$(arg packet_size)"/>
+        <param name="data_size" value="$(arg data_size)"/>
     </node>
 </launch>

--- a/ros/src/peripherals/launchfiles/hydrophones.launch
+++ b/ros/src/peripherals/launchfiles/hydrophones.launch
@@ -1,0 +1,6 @@
+<launch>
+    <arg name="device_id" default="hydrophones"/>
+    <node name="hydrophones" pkg="peripherals" type="hydrophones" respawn="true" respawn_delay="1" >
+        <param name="device_id" value="$(arg device_id)"/>
+    </node>
+</launch>

--- a/ros/src/peripherals/msg/hydro.msg
+++ b/ros/src/peripherals/msg/hydro.msg
@@ -1,0 +1,1 @@
+uint16[] raw_data

--- a/ros/src/peripherals/src/hydrophones.cpp
+++ b/ros/src/peripherals/src/hydrophones.cpp
@@ -1,0 +1,10 @@
+#include <ros/ros.h>
+
+int main(int argc, char** argv)
+{       
+    ros::init("hydrophones");
+    ros::NodeHandle nh("~");
+
+    std::string device_id;
+    nh.getParam("device_id", device_id);
+}

--- a/ros/src/peripherals/src/hydrophones.cpp
+++ b/ros/src/peripherals/src/hydrophones.cpp
@@ -171,7 +171,7 @@ bool hydrophones::acquire_hydro_data(std::vector<peripherals::hydro> &hydro_data
 
     } while(packet_idx < (packet_count - 1));
 
-    connection->flush(); // Sent an extra "NEXT"
+    connection->flush(); 
 
     return true;
 }

--- a/ros/src/peripherals/src/hydrophones.cpp
+++ b/ros/src/peripherals/src/hydrophones.cpp
@@ -9,6 +9,7 @@
 
 #define NUM_HYDROPHONES (4)
 #define PKT_HEADER_SIZE (12)
+#define MAX_RESENDS     (3)
 
 using HydroDataReq = peripherals::hydro_data::Request;
 using HydroDataRes = peripherals::hydro_data::Response;
@@ -21,7 +22,7 @@ public:
     std::string write(const std::string out, bool ignore_response = true, const std::string eol = "\n");
     bool get_raw_data(HydroDataReq &req, HydroDataRes &res);
 private:
-    void acquire_hydro_data(std::vector<peripherals::hydro> &hydro_data);
+    bool acquire_hydro_data(std::vector<peripherals::hydro> &hydro_data);
     uint32_t stm32f4_crc32(uint8_t* data, size_t data_len, uint32_t crc = 0xFFFFFFFF);
     ros::NodeHandle nh;
     std::unique_ptr<serial::Serial> connection = nullptr;
@@ -60,26 +61,26 @@ hydrophones::hydrophones(const std::string port, int baud_rate, int timeout) :
     if(p_size.length() >= 4)
     {   
         packet_size_actual = (p_size[1] << 8) | p_size[0];
-        ROS_ERROR("Packet Size is set to %u", packet_size_actual);
+        ROS_INFO("Packet Size is set to %u", packet_size_actual);
     }
    
     uint16_t data_size_actual;
     if(d_size.length() >= 4)
     {   
         data_size_actual = (d_size[1] << 8) | d_size[0];
-        ROS_ERROR("Data size is set to %u", data_size_actual);
+        ROS_INFO("Data size is set to %u", data_size_actual);
     }
 }
 
 hydrophones::~hydrophones()
-{       
+{      
+    connection->flush();
     connection->close();
 }
 
 std::string hydrophones::write(const std::string out, bool ignore_response, const std::string eol)
 {   
     connection->flush();
-    ROS_ERROR("%s", out.c_str());
     connection->write(out + eol);
     connection->flushOutput();
 
@@ -93,12 +94,10 @@ std::string hydrophones::write(const std::string out, bool ignore_response, cons
 
 bool hydrophones::get_raw_data(HydroDataReq &req, HydroDataRes &res)
 {       
-    acquire_hydro_data(res.hydro);
-
-    return true;
+    return acquire_hydro_data(res.hydro);
 }
 
-void hydrophones::acquire_hydro_data(std::vector<peripherals::hydro> &hydro_data)
+bool hydrophones::acquire_hydro_data(std::vector<peripherals::hydro> &hydro_data)
 {  
     // Initialize the list with all the data
     for(int i = 0; i < NUM_HYDROPHONES; i++)
@@ -113,6 +112,7 @@ void hydrophones::acquire_hydro_data(std::vector<peripherals::hydro> &hydro_data
     uint32_t data_index = 0;
     uint8_t packet_idx = 0;
     uint8_t packet_count = 0;
+    uint8_t resend_count = 0;
     do
     {  
         // Get the packet header and relevant information
@@ -127,7 +127,7 @@ void hydrophones::acquire_hydro_data(std::vector<peripherals::hydro> &hydro_data
         uint16_t packet_size = (header[9] << 8) | header[8];
         uint16_t total_size = (header[11] << 8) | header[10];
 
-        ROS_ERROR("CRC: %u, Packet Index: %u, Packet Count: %u, Packet Size: %u, Total Size: %u", crc, packet_idx, packet_count, packet_size, total_size);
+        //ROS_INFO("CRC: %u, Packet Index: %u, Packet Count: %u, Packet Size: %u, Total Size: %u", crc, packet_idx, packet_count, packet_size, total_size);
 
         // Use header to determine how much data to read
         uint8_t* packet_data = new uint8_t[packet_size];
@@ -136,16 +136,30 @@ void hydrophones::acquire_hydro_data(std::vector<peripherals::hydro> &hydro_data
         // Check to see if there were any communication errors
         uint32_t host_crc = stm32f4_crc32(packet_data, packet_size);
         if(host_crc != crc)
-        {       
-            ROS_ERROR("Communication error. Executing packet resend.");
-            packet_idx = 0; // Do this just in case this is the last packet (get through the while loop)
-            write("RETRY"); // Send the last packet again
+        {      
             delete[] packet_data;
-            continue;
+            if(resend_count < MAX_RESENDS)
+            {
+                ROS_ERROR("Communication error. Executing packet resend.");
+                packet_idx = 0; // Do this just in case this is the last packet (get through the while loop)
+                write("RETRY"); // Send the last packet again
+                resend_count++;
+                continue;
+            }
+            else
+            {   
+                ROS_ERROR("Communication error. Resend count exceeded maximum allowed resends. Failed to read data from hydrophones");
+                return false;
+            }
         }
         
         // Signal the beginning of the next packet transfer
-        write("NEXT");
+        if(packet_idx < (packet_count - 1))
+        {
+            write("NEXT");
+        }
+
+        resend_count = 0;
 
         // Append data to output while we wait
         for(int i = 0; i < (packet_size/2); i++, data_index++)
@@ -157,9 +171,9 @@ void hydrophones::acquire_hydro_data(std::vector<peripherals::hydro> &hydro_data
 
     } while(packet_idx < (packet_count - 1));
 
-    ROS_ERROR("DONE");
-
     connection->flush(); // Sent an extra "NEXT"
+
+    return true;
 }
 
 uint32_t hydrophones::stm32f4_crc32(uint8_t* data, size_t data_len, uint32_t crc)
@@ -175,7 +189,6 @@ uint32_t hydrophones::stm32f4_crc32(uint8_t* data, size_t data_len, uint32_t crc
     for(int i = 0; i < (data_len/4); i++)
     {  
         uint32_t uint32_datum = (data[(i*4)+3] << 24) | (data[(i*4)+2] << 16) | (data[(i*4)+1] << 8) | data[(i*4)];
-        //uint32_t uint32_datum = (data[i*4] << 24) | (data[(i*4)+1] << 16) | (data[(i*4)+2] << 8) | data[(i*4)+3];
         crc = crc ^ uint32_datum;
         for(int j = 0; j < 32; j++)
         {      
@@ -208,9 +221,9 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    ROS_INFO("Using Hydrophones on fd %s\n", srv.response.device_fd.c_str());*/
+    ROS_INFO("Using Hydrophones on fd %s\n", srv.response.device_fd.c_str());
 
-    //hydrophones device(srv.response.device_fd.c_str());
+    hydrophones device(srv.response.device_fd.c_str());*/
     hydrophones device("/dev/ttyS3");
 
     ros::ServiceServer raw_data_srv = nh.advertiseService("getRawData", &hydrophones::get_raw_data, &device);

--- a/ros/src/peripherals/src/hydrophones.cpp
+++ b/ros/src/peripherals/src/hydrophones.cpp
@@ -2,9 +2,10 @@
 
 int main(int argc, char** argv)
 {       
-    ros::init("hydrophones");
+    ros::init(argc, argv, "hydrophones");
     ros::NodeHandle nh("~");
 
     std::string device_id;
     nh.getParam("device_id", device_id);
+
 }

--- a/ros/src/peripherals/src/hydrophones.cpp
+++ b/ros/src/peripherals/src/hydrophones.cpp
@@ -1,11 +1,141 @@
 #include <ros/ros.h>
+#include <vector>
+#include <string>
+#include <serial/serial.h>
+
+#include "monitor/GetSerialDevice.h"
+
+#define NUM_HYDROPHONES (4)
+#define PKT_HEADER_SIZE (12)
+
+
+class hydrophones
+{       
+public:
+    hydrophones(const std::string port, int baud_rate = 115200, int timeout = 1000);
+    ~hydrophones();
+    std::string write(const std::string out, bool ignore_response = true, const std::string eol = "\n");
+    void acquire_hydro_data(std::vector<uint16_t> hydro_data[NUM_HYDROPHONES]);
+private:
+    uint32_t stm32f4_crc32(uint8_t* data, size_t data_len, uint32_t crc = 0xFFFFFFFF);
+    std::unique_ptr<serial::Serial> connection = nullptr;
+};
+
+hydrophones::hydrophones(const std::string port, int baud_rate, int timeout)
+{       
+    ROS_INFO("Connecting to hydrophones on port %s", port.c_str());
+    connection = std::unique_ptr<serial::Serial>(new serial::Serial(port, (u_int32_t)baud_rate, serial::Timeout::simpleTimeout(timeout)));
+}
+
+hydrophones::~hydrophones()
+{       
+    connection->close();
+}
+
+std::string hydrophones::write(const std::string out, bool ignore_response, const std::string eol)
+{   
+    connection->flush();
+    connection->write(out + eol);
+
+    if(ignore_response) 
+    {   
+        return "";
+    }
+
+    return connection->readline(65536ul, eol);
+}
+
+void hydrophones::acquire_hydro_data(std::vector<uint16_t> hydro_data[NUM_HYDROPHONES])
+{   
+    uint8_t header[PKT_HEADER_SIZE];
+    write("ADCDR");
+
+    uint32_t data_index = 0;
+    uint8_t packet_idx = 0;
+    uint8_t packet_count = 0;
+    do
+    {  
+        // Get the packet header and relevant information
+        connection->read(header, PKT_HEADER_SIZE);
+        uint32_t crc = (header[3] << 24) | (header[2] << 16) | (header[1] << 8) | header[0];
+        packet_count = header[6];
+        packet_idx = header[7];
+        uint16_t packet_size = (header[9] << 8) | header[8];
+
+        // Use header to determine how much data to read
+        uint8_t* packet_data = new uint8_t[packet_size];
+        connection->read(packet_data, packet_size);
+
+        // Check to see if there were any communication errors
+        if(stm32f4_crc32(packet_data, packet_size) != crc)
+        {       
+            ROS_ERROR("Communication error. Executing packet resend.");
+            packet_idx--; // Do this just in case this is the last packet (get through the while loop)
+            write("RETRY"); // Send the last packet again
+            continue;
+        }
+        
+        // Signal the beginning of the next packet transfer
+        write("NEXT");
+
+        // Append data to output while we wait
+        for(int i = 0; i < (packet_size/2); i++, data_index++)
+        {   
+            hydro_data[data_index % NUM_HYDROPHONES].push_back((packet_data[(i*2)+1] << 8) | packet_data[i*2]); 
+        }
+
+    } while(packet_idx < (packet_count - 1));
+
+    connection->flush(); // Sent an extra "NEXT"
+}
+
+uint32_t hydrophones::stm32f4_crc32(uint8_t* data, size_t data_len, uint32_t crc)
+{       
+    // Make sure data length is a multiple of 4
+    if(data_len % 4)
+    {   
+        ROS_ERROR("Invalid data for STM32F4 CRC. Data length must be a multiple of 4.");
+        return 0;
+    }
+
+    // Compute the CRC 32 bits at a time
+    for(int i = 0; i < (data_len/4); i++)
+    {   
+        uint32_t uint32_datum = (data[(i*4)+3] << 24) | (data[(i*4)+2] << 16) | (data[(i*4)+1] << 8) | data[(i*4)];
+        crc ^= uint32_datum;
+        for(int j = 0; j < 32; j++)
+        {       
+            if(crc & 0x80000000)
+            {       
+                crc = (crc << 1) & 0x04C11DB7;
+            }
+            else
+            {   
+                crc <<= 1;
+            }
+        }
+    }
+
+    return crc;
+}
 
 int main(int argc, char** argv)
 {       
     ros::init(argc, argv, "hydrophones");
     ros::NodeHandle nh("~");
 
-    std::string device_id;
-    nh.getParam("device_id", device_id);
+    monitor::GetSerialDevice srv;
+    nh.getParam("device_id", srv.request.device_id);
 
+    ros::ServiceClient client = nh.serviceClient<monitor::GetSerialDevice>("/serial_manager/GetDevicePort");
+    if(!client.call(srv)) {     
+        ROS_INFO("Couldn't get \"%s\" file descriptor. Shutting down", srv.request.device_id.c_str());
+        return 1;
+    }
+
+    ROS_INFO("Using Hydrophones on fd %s\n", srv.response.device_fd.c_str());
+   
+    ros::spin();
+
+    return 0;
 }

--- a/ros/src/peripherals/src/hydrophones.cpp
+++ b/ros/src/peripherals/src/hydrophones.cpp
@@ -36,6 +36,7 @@ std::string hydrophones::write(const std::string out, bool ignore_response, cons
 {   
     connection->flush();
     connection->write(out + eol);
+    connection->flushOutput();
 
     if(ignore_response) 
     {   
@@ -56,7 +57,11 @@ void hydrophones::acquire_hydro_data(std::vector<uint16_t> hydro_data[NUM_HYDROP
     do
     {  
         // Get the packet header and relevant information
-        connection->read(header, PKT_HEADER_SIZE);
+        uint8_t lines;
+        if((lines = connection->read(header, PKT_HEADER_SIZE)) != PKT_HEADER_SIZE)
+        {       
+            ROS_ERROR("Did not read enough lines! Read only %u lines.", lines);
+        }
         uint32_t crc = (header[3] << 24) | (header[2] << 16) | (header[1] << 8) | header[0];
         packet_count = header[6];
         packet_idx = header[7];
@@ -67,11 +72,13 @@ void hydrophones::acquire_hydro_data(std::vector<uint16_t> hydro_data[NUM_HYDROP
         connection->read(packet_data, packet_size);
 
         // Check to see if there were any communication errors
+        uint32_t host_crc = stm32f4_crc32(packet_data, packet_size);
         if(stm32f4_crc32(packet_data, packet_size) != crc)
         {       
             ROS_ERROR("Communication error. Executing packet resend.");
-            packet_idx--; // Do this just in case this is the last packet (get through the while loop)
+            packet_idx = 0; // Do this just in case this is the last packet (get through the while loop)
             write("RETRY"); // Send the last packet again
+            delete[] packet_data;
             continue;
         }
         
@@ -84,13 +91,17 @@ void hydrophones::acquire_hydro_data(std::vector<uint16_t> hydro_data[NUM_HYDROP
             hydro_data[data_index % NUM_HYDROPHONES].push_back((packet_data[(i*2)+1] << 8) | packet_data[i*2]); 
         }
 
+        delete[] packet_data;
+
     } while(packet_idx < (packet_count - 1));
+
+    ROS_ERROR("DONE");
 
     connection->flush(); // Sent an extra "NEXT"
 }
 
 uint32_t hydrophones::stm32f4_crc32(uint8_t* data, size_t data_len, uint32_t crc)
-{       
+{
     // Make sure data length is a multiple of 4
     if(data_len % 4)
     {   
@@ -100,18 +111,19 @@ uint32_t hydrophones::stm32f4_crc32(uint8_t* data, size_t data_len, uint32_t crc
 
     // Compute the CRC 32 bits at a time
     for(int i = 0; i < (data_len/4); i++)
-    {   
+    {  
         uint32_t uint32_datum = (data[(i*4)+3] << 24) | (data[(i*4)+2] << 16) | (data[(i*4)+1] << 8) | data[(i*4)];
-        crc ^= uint32_datum;
+        //uint32_t uint32_datum = (data[i*4] << 24) | (data[(i*4)+1] << 16) | (data[(i*4)+2] << 8) | data[(i*4)+3];
+        crc = crc ^ uint32_datum;
         for(int j = 0; j < 32; j++)
-        {       
+        {      
             if(crc & 0x80000000)
-            {       
-                crc = (crc << 1) & 0x04C11DB7;
+            {      
+                crc = (crc << 1) ^ 0x04C11DB7;
             }
             else
             {   
-                crc <<= 1;
+                crc = crc << 1;
             }
         }
     }
@@ -127,13 +139,19 @@ int main(int argc, char** argv)
     monitor::GetSerialDevice srv;
     nh.getParam("device_id", srv.request.device_id);
 
-    ros::ServiceClient client = nh.serviceClient<monitor::GetSerialDevice>("/serial_manager/GetDevicePort");
+    /*ros::ServiceClient client = nh.serviceClient<monitor::GetSerialDevice>("/serial_manager/GetDevicePort");
     if(!client.call(srv)) {     
         ROS_INFO("Couldn't get \"%s\" file descriptor. Shutting down", srv.request.device_id.c_str());
         return 1;
     }
 
-    ROS_INFO("Using Hydrophones on fd %s\n", srv.response.device_fd.c_str());
+    ROS_INFO("Using Hydrophones on fd %s\n", srv.response.device_fd.c_str());*/
+
+    //hydrophones device(srv.response.device_fd.c_str());
+    hydrophones device("/dev/ttyS3");
+
+    std::vector<uint16_t> data[4];
+    device.acquire_hydro_data(data);
    
     ros::spin();
 

--- a/ros/src/peripherals/src/hydrophones.cpp
+++ b/ros/src/peripherals/src/hydrophones.cpp
@@ -215,7 +215,7 @@ int main(int argc, char** argv)
     nh.getParam("device_id", srv.request.device_id);
 
 
-    /*ros::ServiceClient client = nh.serviceClient<monitor::GetSerialDevice>("/serial_manager/GetDevicePort");
+    ros::ServiceClient client = nh.serviceClient<monitor::GetSerialDevice>("/serial_manager/GetDevicePort");
     if(!client.call(srv)) {     
         ROS_INFO("Couldn't get \"%s\" file descriptor. Shutting down", srv.request.device_id.c_str());
         return 1;
@@ -223,8 +223,7 @@ int main(int argc, char** argv)
 
     ROS_INFO("Using Hydrophones on fd %s\n", srv.response.device_fd.c_str());
 
-    hydrophones device(srv.response.device_fd.c_str());*/
-    hydrophones device("/dev/ttyS3");
+    hydrophones device(srv.response.device_fd.c_str());
 
     ros::ServiceServer raw_data_srv = nh.advertiseService("getRawData", &hydrophones::get_raw_data, &device);
         

--- a/ros/src/peripherals/srv/hydro_data.srv
+++ b/ros/src/peripherals/srv/hydro_data.srv
@@ -1,0 +1,2 @@
+---
+peripherals/hydro[] hydro


### PR DESCRIPTION
Changes are for hydrophone node, and can be accepted under #5 . Service call added to get the raw data from the hydrophones. If this gets accepted, I think a new issue should be added that should be to compute the fft on the hydrophone node. I think that this should be done due to the large amounts of data that would need to be sent otherwise. The service call is mostly for testing purposes and is there in case we ever want to grab the data to look at etc. In launch file the packet size can be configured, as well as the data size, both in bytes. Packet size must be a multiple of 4. Data size must be a multiple of 8. (Firmware handles both these, and will round down to the nearest multiple). Increasing the packet size will increase the speed at which the service call operates, though if it goes too high, the USB driver might fail (my VM can only handle a few hundred bytes at a time before failure, though my regular OS can handle 4KB). To improve speed, this should be tested on the Jetson to see at what packet size the code starts to fail. Data size refers to the total amount of data acquired by the hydrophone sensors. 