### PR TITLE
caught sigint instead of keyboard exception so that port is closed cleanly

### DIFF
--- a/ros/src/webgui/server.py
+++ b/ros/src/webgui/server.py
@@ -1,14 +1,21 @@
 #!/usr/bin/python
 import SimpleHTTPServer
 import SocketServer
+import signal
+import sys
 import os
 
-if __name__ == "__main__":
-    PORT = 12345
-    Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
-    httpd = SocketServer.TCPServer(("0.0.0.0", PORT), Handler)
+PORT = 12345
+Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
+httpd = SocketServer.TCPServer(("0.0.0.0", PORT), Handler)
+
+def signal_handler(signal, frame):
+    httpd.server_close()
+    sys.exit(0)
+    
+if __name__ == '__main__':
     os.chdir(os.path.dirname(__file__))
-    try:
-        httpd.serve_forever()
-    finally:
-        httpd.server_close()
+    signal.signal(signal.SIGINT, signal_handler)
+    httpd.serve_forever()
+        
+        


### PR DESCRIPTION
ROS sends SIGINT to kill an application, but Python doesn't natively handle signals as exceptions. Ctrl-C does generate KeyboardException only when running python directlty 